### PR TITLE
fixed shortest path bug

### DIFF
--- a/src/trackteroid/session.py
+++ b/src/trackteroid/session.py
@@ -102,10 +102,15 @@ class Session(object):
     def parsed_relationships(self):
         if not self._session.server_url in _PARSED_RELATIONSHIPS_CACHE:
             relationship_parser = RelationshipsParser(ftrack_session=self._session)
-            # TODO: why do we have to exclude certain types?
+            # types such as "Context" are ambiguous and cannot be used to extract direct relationships
+            # example structure - Seq -> Folder -> Shot
+            # in this case, establishing a relationship from Seq to Shot is impossible as would any other
+            # that went through "parent" or "children" for example
             relationship_parser.exclude_types = {"Context"}
             relationship_parser.parse_session_schemas()
-            # TODO: why do we have to exclude certain attributes?
+            # attributes that group things cannot be used to extract relationships
+            # as an example, "descendants" lists all children and children of children and so on,
+            # so they are all flattened with their relationships removed
             relationship_parser.attributes_blacklist = {"descendants", "ancestors", "status_changes"}
             relationship_parser.extract_all_entity_relations()
             _PARSED_RELATIONSHIPS_CACHE[self._session.server_url] = relationship_parser


### PR DESCRIPTION
bug fixed, short explanation

example (propC having two paths):

entity
  - propA
      - propD
      - propE
      - propC
  - propB
  - propC
  
The recursive function would go in sequence, find propC under propA and mark it as "found" - encounters propC later and skips it as "already found" - effectively using the longer path

This is fixed now, before recursing, propA, propB and propC on the first level are marked as found, ensuring the shortest path is always taken.

I also added some inline comments to make the code (hopefully) easier to understand