### PR TITLE
fix broken user config load

### DIFF
--- a/src/trackteroid/configuration.py
+++ b/src/trackteroid/configuration.py
@@ -90,7 +90,7 @@ def _override_configuration():
         for attribute in relevant_attributes:
             if hasattr(custom_configuration, attribute):
                 _LOG.info(f"Adding '{attribute}' from user configuration.")
-                if attribute in _CALLABLES_REQUIRE_FALLBACKS:
+                if attribute in _CALLABLES_REQUIRE_FALLBACK:
                     globals()[attribute] = _fallback_decorator(
                         globals()[attribute],
                         attribute
@@ -117,7 +117,7 @@ WARN_ON_INJECT = False
 ############################################################################################
 
 _LOG = logging.getLogger(f"{LOGGING_NAMESPACE}.configuration")
-_CALLABLES_REQUIRE_FALLBACKS = [
+_CALLABLES_REQUIRE_FALLBACK = [
     "RELATIONSHIPS_RESOLVER",
 ]
 

--- a/src/trackteroid/configuration.py
+++ b/src/trackteroid/configuration.py
@@ -34,37 +34,74 @@ import os
 import traceback
 import sys
 
+import wrapt
+
+
+def _fallback_decorator(fallback_func, attribute):
+    """ fallback mechanism for the wrapped function on the associated config entry
+
+    Args:
+        fallback_func callable: function to wrap
+        attribute: name of the attribute the fallback will be applied to
+
+    Returns:
+        callable: function wrapper
+
+    """
+    @wrapt.decorator
+    def wrapper(wrapped, instance, args, kwargs):
+        try:
+            return wrapped(*args, **kwargs)
+        except:
+            _LOG.error(
+                f"Calling '{attribute}' raised an exception. Falling back to default implementation!",
+                exc_info=True
+            )
+            return fallback_func(*args, **kwargs)
+
+    return wrapper
 
 
 def _override_configuration():
-    """ idenfities and parses a user configuration and applies relevant attributes to this module
+    """ identifies and parses a user configuration and applies relevant attributes to this module
 
     """
     _custom_configuration = os.getenv("TRACKTEROID_CONFIGURATION", False)
     # try our best to source a custom configuration
     if _custom_configuration:
         if not os.path.exists(_custom_configuration):
-            raise OSError("Custom configuration `{}` doesn't exist.".format(_custom_configuration))
+            raise OSError(f"Custom configuration `{_custom_configuration}` doesn't exist.")
         if not os.path.splitext(_custom_configuration)[1] in [".py"]:
-            raise AssertionError("Custom configuration must `{}` be a .py file.".format(_custom_configuration))
+            raise AssertionError(f"Custom configuration must `{_custom_configuration}` be a .py file.")
 
-        _LOG.info("Custom configuration specified in `{}`. Trying to load...".format(_custom_configuration))
+        _LOG.info(f"Custom configuration specified in `{_custom_configuration}`. Trying to load...")
         try:
-            custom_configuration = importlib.load_source("configuration", _custom_configuration)
+            spec = importlib.util.spec_from_file_location("custom_configuration", _custom_configuration)
+            custom_configuration = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(custom_configuration)
         except:
             raise RuntimeError(
-                "Failed to load custom configuration.\n{}".format("\n".join(traceback.format_exception(*sys.exc_info())))
+                "Failed to load custom configuration.\n{}".format(
+                    "\n".join(traceback.format_exception(*sys.exc_info()))
+                )
             )
 
         relevant_attributes = [_ for _ in globals().keys() if _.isupper() and not _.startswith("_")]
         for attribute in relevant_attributes:
             if hasattr(custom_configuration, attribute):
-                _LOG.info("Adding '{}' from user configuration.".format(attribute))
-                globals()[attribute] = getattr(custom_configuration, attribute)
+                _LOG.info(f"Adding '{attribute}' from user configuration.")
+                if attribute in _CALLABLES_REQUIRE_FALLBACKS:
+                    globals()[attribute] = _fallback_decorator(
+                        globals()[attribute],
+                        attribute
+                    )(getattr(custom_configuration, attribute))
+                else:
+                    globals()[attribute] = getattr(custom_configuration, attribute)
+
 
 # default entries - ALL upper variable names in here can be set in custom user configuration
 ############################################################################################
-# TODO: add example output
+
 # A functions that gets the current api version string and would return a custom entities
 # schema used for relationship resolutions.
 RELATIONSHIPS_RESOLVER = lambda api_version: {}
@@ -79,7 +116,10 @@ ALLOWED_FOR_DELETION_RESOLVER = lambda session, type_name: True
 WARN_ON_INJECT = False
 ############################################################################################
 
-_LOG = logging.getLogger("{}.configuration".format(LOGGING_NAMESPACE))
+_LOG = logging.getLogger(f"{LOGGING_NAMESPACE}.configuration")
+_CALLABLES_REQUIRE_FALLBACKS = [
+    "RELATIONSHIPS_RESOLVER",
+]
 
 _override_configuration()
 


### PR DESCRIPTION
Also, handle certain config entries more gracefully by preserving the original behavior in case the override would produce an exception. This is primarily important for a
RELATIONSHIPS_RESOLVER at the moment that would otherwise break the import of the trackteroid.